### PR TITLE
Update ILAng version requirement for new bit-vector constant numeric. 

### DIFF
--- a/cores/Nibbler/RISC-V-ILA/.clang-format
+++ b/cores/Nibbler/RISC-V-ILA/.clang-format
@@ -1,0 +1,8 @@
+---
+Language:         Cpp
+BasedOnStyle:     LLVM
+PointerAlignment: Left
+Standard:         Cpp11
+UseTab:           Never
+...
+

--- a/cores/Nibbler/RISC-V-ILA/CMakeLists.txt
+++ b/cores/Nibbler/RISC-V-ILA/CMakeLists.txt
@@ -20,7 +20,7 @@ set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 ##
 ## ilang
 ##
-find_package(ilang REQUIRED)
+find_package(ilang REQUIRED 1.0.1)
 
 
 # ---------------------------------------------------------------------------- #

--- a/cores/Nibbler/RISC-V-ILA/include/riscvIla.hpp
+++ b/cores/Nibbler/RISC-V-ILA/include/riscvIla.hpp
@@ -47,27 +47,27 @@ private:
   ExprRef csr_index;
 
 protected:
-  ExprRef indexIntoGPR(const ExprRef &idxBits);
-  void UpdateGPR(InstrRef &inst, const ExprRef &idxBits, const ExprRef &val);
+  ExprRef indexIntoGPR(const ExprRef& idxBits);
+  void UpdateGPR(InstrRef& inst, const ExprRef& idxBits, const ExprRef& val);
 
   ExprRef bv(NumericType val) { return BvConst(val, XLEN); }
-  ExprRef zext(const ExprRef &v) { return ZExt(v, XLEN); }
-  ExprRef sext(const ExprRef &v) { return SExt(v, XLEN); }
+  ExprRef zext(const ExprRef& v) { return ZExt(v, XLEN); }
+  ExprRef sext(const ExprRef& v) { return SExt(v, XLEN); }
 
-  ExprRef getSlice(const ExprRef &word, const ExprRef &lowBits, int width,
+  ExprRef getSlice(const ExprRef& word, const ExprRef& lowBits, int width,
                    bool unSigned);
-  ExprRef CombineSlices(const ExprRef &word, const ExprRef &lowBits, int width,
-                        const ExprRef &old);
+  ExprRef CombineSlices(const ExprRef& word, const ExprRef& lowBits, int width,
+                        const ExprRef& old);
 
   // privileged model will overload these to insert their address translation
-  virtual ExprRef FetchFromMem(const ExprRef &m, const ExprRef &addr) {
+  virtual ExprRef FetchFromMem(const ExprRef& m, const ExprRef& addr) {
     return Load(m, addr);
   }
-  virtual ExprRef LoadFromMem(const ExprRef &m, const ExprRef &addr) {
+  virtual ExprRef LoadFromMem(const ExprRef& m, const ExprRef& addr) {
     return Load(m, addr);
   }
-  virtual ExprRef StoreToMem(const ExprRef &m, const ExprRef &addr,
-                             const ExprRef &data) {
+  virtual ExprRef StoreToMem(const ExprRef& m, const ExprRef& addr,
+                             const ExprRef& data) {
     return Store(m, addr, data);
   }
 

--- a/cores/Nibbler/RISC-V-ILA/include/riscvIla.hpp
+++ b/cores/Nibbler/RISC-V-ILA/include/riscvIla.hpp
@@ -23,7 +23,6 @@ public:
   Ila model;
 
 private:
-
   ExprRef pc;
   ExprRef mem;
   std::vector<ExprRef> GPR; // R0-R31
@@ -48,27 +47,27 @@ private:
   ExprRef csr_index;
 
 protected:
-  ExprRef indexIntoGPR(const ExprRef& idxBits);
-  void UpdateGPR(InstrRef& inst, const ExprRef& idxBits, const ExprRef& val);
+  ExprRef indexIntoGPR(const ExprRef &idxBits);
+  void UpdateGPR(InstrRef &inst, const ExprRef &idxBits, const ExprRef &val);
 
-  ExprRef bv(int val) { return BvConst(val, XLEN); }
-  ExprRef zext(const ExprRef& v) { return ZExt(v, XLEN); }
-  ExprRef sext(const ExprRef& v) { return SExt(v, XLEN); }
+  ExprRef bv(NumericType val) { return BvConst(val, XLEN); }
+  ExprRef zext(const ExprRef &v) { return ZExt(v, XLEN); }
+  ExprRef sext(const ExprRef &v) { return SExt(v, XLEN); }
 
-  ExprRef getSlice(const ExprRef& word, const ExprRef& lowBits, int width,
+  ExprRef getSlice(const ExprRef &word, const ExprRef &lowBits, int width,
                    bool unSigned);
-  ExprRef CombineSlices(const ExprRef& word, const ExprRef& lowBits, int width,
-                        const ExprRef& old);
+  ExprRef CombineSlices(const ExprRef &word, const ExprRef &lowBits, int width,
+                        const ExprRef &old);
 
   // privileged model will overload these to insert their address translation
-  virtual ExprRef FetchFromMem(const ExprRef& m, const ExprRef& addr) {
+  virtual ExprRef FetchFromMem(const ExprRef &m, const ExprRef &addr) {
     return Load(m, addr);
   }
-  virtual ExprRef LoadFromMem(const ExprRef& m, const ExprRef& addr) {
+  virtual ExprRef LoadFromMem(const ExprRef &m, const ExprRef &addr) {
     return Load(m, addr);
   }
-  virtual ExprRef StoreToMem(const ExprRef& m, const ExprRef& addr,
-                             const ExprRef& data) {
+  virtual ExprRef StoreToMem(const ExprRef &m, const ExprRef &addr,
+                             const ExprRef &data) {
     return Store(m, addr, data);
   }
 

--- a/cores/Nibbler/RISC-V-ILA/verification/.gitignore
+++ b/cores/Nibbler/RISC-V-ILA/verification/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
- Update to require ILAng v1.0.1 (in-progress) for new bit-vector constant numeric types.
- Adapt RISC-V helper function `bv` to the new modification.
- Add placeholder for the `verification` folder. 