### PR TITLE
AES fix

### DIFF
--- a/accls/AES/AES-ILA-RTL/refinement/ref-rel-inst-cond-uaes.json
+++ b/accls/AES/AES-ILA-RTL/refinement/ref-rel-inst-cond-uaes.json
@@ -3,8 +3,7 @@
     "~(aes_step && aes_reg_state == 2) || ( byte_counter == 0 )",
     "~(aes_reg_state != 0) || ((operated_bytes_count == block_counter))",
     "~(aes_reg_state != 0) || (uaes_ctr == aes_reg_ctr + block_counter)",
-    "block_counter[3:0] == 4'd0",
-    "~(aes_reg_state == 2) || (aes_time_enough == 1)"
+    "block_counter[3:0] == 4'd0"
   ],
 
   "instructions": [

--- a/accls/AES/AES-ILA-RTL/refinement/ref-rel-var-map.json
+++ b/accls/AES/AES-ILA-RTL/refinement/ref-rel-var-map.json
@@ -39,7 +39,9 @@
                         "(~ ( m0.cmd == 2 )) || ( m1.wr == 1)" , 
                         "(~ ( m0.cmd == 1 )) || ( m1.wr == 0)",
                         " m1.xram_addr ==  __MEM_XRAM_0_raddr ",
-                        " m1.xram_addr ==  __MEM_XRAM_0_waddr "
+                        " m1.xram_addr ==  __MEM_XRAM_0_waddr ",
+                        // for the 8051 soc, this now becomes an assumption
+                        "~(aes_reg_state == 2) || (aes_time_enough == 1)"
                       ],
 
   "functions":{

--- a/accls/AES/AES-ILA-RTL/verilog/aes_top.v
+++ b/accls/AES/AES-ILA-RTL/verilog/aes_top.v
@@ -298,7 +298,7 @@ always @(posedge clk) begin
 	end
 end
 
-assign aes_time_enough = aes_time_counter >= 5'd10;
+assign aes_time_enough = aes_time_counter >= 5'd20;
 
 
 // Actual encryption happens here.

--- a/accls/AES/AES-RTL-C/HwCbmc/src/aes_top.v
+++ b/accls/AES/AES-RTL-C/HwCbmc/src/aes_top.v
@@ -298,7 +298,7 @@ always @(posedge clk) begin
 	end
 end
 
-assign aes_time_enough = aes_time_counter >= 5'd10;
+assign aes_time_enough = aes_time_counter >= 5'd20;
 
 
 // Actual encryption happens here.

--- a/accls/AES/AES-RTL-C/Verilog/aes_top.v
+++ b/accls/AES/AES-RTL-C/Verilog/aes_top.v
@@ -302,7 +302,7 @@ always @(posedge clk) begin
 	end
 end
 
-assign aes_time_enough = aes_time_counter >= 5'd10;
+assign aes_time_enough = aes_time_counter >= 5'd20;
 
 
 // Actual encryption happens here.

--- a/tutorials/aes/verilog/aes_top.v
+++ b/tutorials/aes/verilog/aes_top.v
@@ -298,7 +298,7 @@ always @(posedge clk) begin
 	end
 end
 
-assign aes_time_enough = aes_time_counter >= 5'd10;
+assign aes_time_enough = aes_time_counter >= 5'd20;
 
 
 // Actual encryption happens here.


### PR DESCRIPTION
In the 8051 SoC, the `aes_time_counter` was actually not need because the interface is not reacting fast enough to generate `ack` in the same cycle as the request. However, this is not safe for a faster interface.